### PR TITLE
improved command to not accidentally stage unwanted changes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx pretty-quick --staged
-git add .
+git update-index --again


### PR DESCRIPTION
The previous configuration would stage all modified files. This would be bad if you didn't want to stage all files.