### PR TITLE
Fixed styling on Submission Form + Ctrl Enter

### DIFF
--- a/app/src/app.scss
+++ b/app/src/app.scss
@@ -35,6 +35,15 @@ $theme-colors: map-merge($theme-colors, $custom-colors);
     --button-hover-border: #e3daf8;
 }
 
+.finalTextBox textarea {
+    border: 0;
+    outline: 0;
+    padding: 5px;
+    textarea:focus {
+        outline: none;
+    }
+}
+
 $font-family-base: var(--open-sans);
 
 @import "bootstrap/scss/root"; // Required

--- a/app/src/app.scss
+++ b/app/src/app.scss
@@ -31,7 +31,7 @@ $theme-colors: map-merge($theme-colors, $custom-colors);
     --purple-textbox: #7040d6;
     --purple-button-default: #a07ee8;
     --purple-button-hover: #{$elle-purple};
-    --purple-button-focus: #3a09a2;
+    --purple-button-focus: #{$elle-purple};
     --button-hover-border: #e3daf8;
 }
 

--- a/app/src/app.scss
+++ b/app/src/app.scss
@@ -28,11 +28,10 @@ $theme-colors: map-merge($theme-colors, $custom-colors);
     --text-normal: #faf8f8;
     --text-success: #b6faa2;
     --text-error: #fc4528;
-    --purple-textbox: #7040d6;
-    --purple-button-default: #a07ee8;
-    --purple-button-hover: #{$elle-purple};
-    --purple-button-focus: #{$elle-purple};
-    --button-hover-border: #e3daf8;
+    --purp-textbox: #7040d6;
+    --purp-button-default: #a07ee8;
+    --purp-button-hover: #3a09a1;
+    --purp-button-focus: #3a09a2;
 }
 
 $font-family-base: var(--open-sans);

--- a/app/src/app.scss
+++ b/app/src/app.scss
@@ -30,7 +30,7 @@ $theme-colors: map-merge($theme-colors, $custom-colors);
     --text-error: #fc4528;
     --purple-textbox: #7040d6;
     --purple-button-default: #a07ee8;
-    --purple-button-hover: #3a09a1;
+    --purple-button-hover: #{$elle-purple};
     --purple-button-focus: #3a09a2;
     --button-hover-border: #e3daf8;
 }

--- a/app/src/app.scss
+++ b/app/src/app.scss
@@ -28,10 +28,11 @@ $theme-colors: map-merge($theme-colors, $custom-colors);
     --text-normal: #faf8f8;
     --text-success: #b6faa2;
     --text-error: #fc4528;
-    --purp-textbox: #7040d6;
-    --purp-button-default: #a07ee8;
-    --purp-button-hover: #3a09a1;
-    --purp-button-focus: #3a09a2;
+    --purple-textbox: #7040d6;
+    --purple-button-default: #a07ee8;
+    --purple-button-hover: #3a09a1;
+    --purple-button-focus: #3a09a2;
+    --button-hover-border: #e3daf8;
 }
 
 $font-family-base: var(--open-sans);

--- a/app/src/components/submissionPage/SnapSubmissionStyles.ts
+++ b/app/src/components/submissionPage/SnapSubmissionStyles.ts
@@ -13,6 +13,7 @@ export const SnapSubmissionColumnDiv = styled.div`
     padding: 5%;
     border-radius: 10px 10px 10px 10px;
     @media (max-width: 576px) {
+        border-radius: 10px 10px 10px 10px;
         height: 380px;
         margin-top: 10px;
     }
@@ -68,23 +69,23 @@ export const SnapItButton = styled.button`
     margin-left: 5%;
     margin-right: auto;
     width: 85%;
-    background: var(--purple-button-default);
+    background: var(--purp-button-default);
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
     border-radius: 10px;
     border: 0px;
     &:hover {
-        background-color: var(--purple-button-hover);
-        border: 2px solid var(--button-hover-border);
+        background-color: var(--purp-button-hover);s
+        border: 2px solid #e3daf8;
         box-sizing: border-box;
         box-shadow: 2px 4px 4px rgba(0, 0, 0, 0.25);
     }
     &:focus {
-        background-color: var(--purple-button-focus);
+        background-color: var(--purp-button-focus);
         border: 0px;
         box-shadow: none;
     }
     &:active {
-        background-color: var(--purple-button-focus);
+        background-color: var(--purp-button-focus);
         border: 0px;
         box-shadow: none;
     }

--- a/app/src/components/submissionPage/SnapSubmissionStyles.ts
+++ b/app/src/components/submissionPage/SnapSubmissionStyles.ts
@@ -9,7 +9,7 @@ export const ElleImg = styled(Elle)`
 
 export const SnapSubmissionColumnDiv = styled.div`
     height: 400px;
-    background-color: #7040d6;
+    background-color: var(--purple-textbox);
     padding: 5%;
     border-radius: 10px 10px 10px 10px;
     @media (max-width: 576px) {
@@ -38,14 +38,25 @@ export const SnapCupTextArea = styled(MentionsInput)`
     resize: none;
     background-color: white;
     height: 180px;
+    &:focus {
+        outline: none;
+    }
 `;
 
 export const TaggedTeamMembers = styled.input`
+    font-family: var(--open-sans);
+    font-style: normal;
+    font-weight: normal;
+    font-size: 15px;
+    line-height: 22px;
     width: 95%;
-    background-color: ;
+    background-color: var(--purple-textbox);
     border: 0px;
     border-bottom: 1px solid;
     border-color: white;
+    &:focus {
+        outline: none;
+    }
 `;
 
 export const LabelText = styled.p`

--- a/app/src/components/submissionPage/SnapSubmissionStyles.ts
+++ b/app/src/components/submissionPage/SnapSubmissionStyles.ts
@@ -13,7 +13,6 @@ export const SnapSubmissionColumnDiv = styled.div`
     padding: 5%;
     border-radius: 10px 10px 10px 10px;
     @media (max-width: 576px) {
-        border-radius: 10px 10px 10px 10px;
         height: 380px;
         margin-top: 10px;
     }
@@ -69,23 +68,23 @@ export const SnapItButton = styled.button`
     margin-left: 5%;
     margin-right: auto;
     width: 85%;
-    background: var(--purp-button-default);
+    background: var(--purple-button-default);
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
     border-radius: 10px;
     border: 0px;
     &:hover {
-        background-color: var(--purp-button-hover);s
-        border: 2px solid #e3daf8;
+        background-color: var(--purple-button-hover);
+        border: 2px solid var(--button-hover-border);
         box-sizing: border-box;
         box-shadow: 2px 4px 4px rgba(0, 0, 0, 0.25);
     }
     &:focus {
-        background-color: var(--purp-button-focus);
+        background-color: var(--purple-selected);
         border: 0px;
         box-shadow: none;
     }
     &:active {
-        background-color: var(--purp-button-focus);
+        background-color: var(--purple-selected);
         border: 0px;
         box-shadow: none;
     }

--- a/app/src/components/submissionPage/SnapSubmissionStyles.ts
+++ b/app/src/components/submissionPage/SnapSubmissionStyles.ts
@@ -79,12 +79,12 @@ export const SnapItButton = styled.button`
         box-shadow: 2px 4px 4px rgba(0, 0, 0, 0.25);
     }
     &:focus {
-        background-color: var(--purple-selected);
+        background-color: var(--purple-button-focus);
         border: 0px;
         box-shadow: none;
     }
     &:active {
-        background-color: var(--purple-selected);
+        background-color: var(--purple-button-focus);
         border: 0px;
         box-shadow: none;
     }

--- a/app/src/components/submissionPage/SnapSubmissionStyles.ts
+++ b/app/src/components/submissionPage/SnapSubmissionStyles.ts
@@ -12,6 +12,9 @@ export const SnapSubmissionColumnDiv = styled.div`
     padding-top: 3%;
     padding-bottom: 3%;
     border-radius: 10px 10px 10px 10px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 `;
 
 export const SnapCupText = styled.p`
@@ -33,7 +36,7 @@ export const SnapCupTextArea = styled(MentionsInput)`
     width: 95%;
     resize: none;
     background-color: white;
-    height: 180px;
+    height: 250px;
     outline: none;
 `;
 

--- a/app/src/components/submissionPage/SnapSubmissionStyles.ts
+++ b/app/src/components/submissionPage/SnapSubmissionStyles.ts
@@ -34,10 +34,7 @@ export const SnapCupTextArea = styled(MentionsInput)`
     resize: none;
     background-color: white;
     height: 180px;
-    &:focus {
-        outline: none;
-        border: none;
-    }
+    outline: none;
 `;
 
 export const TaggedTeamMembers = styled.input`

--- a/app/src/components/submissionPage/SnapSubmissionStyles.ts
+++ b/app/src/components/submissionPage/SnapSubmissionStyles.ts
@@ -8,14 +8,10 @@ export const ElleImg = styled(Elle)`
 `;
 
 export const SnapSubmissionColumnDiv = styled.div`
-    height: 400px;
     background-color: var(--purple-textbox);
-    padding: 5%;
+    padding-top: 3%;
+    padding-bottom: 3%;
     border-radius: 10px 10px 10px 10px;
-    @media (max-width: 576px) {
-        height: 380px;
-        margin-top: 10px;
-    }
 `;
 
 export const SnapCupText = styled.p`
@@ -40,6 +36,7 @@ export const SnapCupTextArea = styled(MentionsInput)`
     height: 180px;
     &:focus {
         outline: none;
+        border: none;
     }
 `;
 
@@ -56,6 +53,9 @@ export const TaggedTeamMembers = styled.input`
     border-color: white;
     &:focus {
         outline: none;
+        border: 0px;
+        border-bottom: 1px solid;
+        border-color: white;
     }
 `;
 

--- a/app/src/components/submissionPage/SubmissionTextBox.tsx
+++ b/app/src/components/submissionPage/SubmissionTextBox.tsx
@@ -19,6 +19,7 @@ import {
     LabelText,
     TaggedTeamMembers,
     HelperText,
+    VerticallyCenteredDiv,
 } from "./SnapSubmissionStyles";
 
 export interface Props {
@@ -91,17 +92,6 @@ const SubmissionTextBox: React.FunctionComponent = (props: Props) => {
                         </div>
                         <div className="col col-lg-7">
                             <form>
-                                <div>
-                                    <LabelText>Tag Team Members</LabelText>
-                                    <TaggedTeamMembers
-                                        type="text"
-                                        className="form-control"
-                                    />
-                                    <HelperText>
-                                        Enter their email address or use the @
-                                        symbol
-                                    </HelperText>
-                                </div>
                                 <div className="form-group">
                                     <LabelText>Message:</LabelText>
                                     <SnapCupTextArea

--- a/app/src/components/submissionPage/SubmissionTextBox.tsx
+++ b/app/src/components/submissionPage/SubmissionTextBox.tsx
@@ -19,7 +19,6 @@ import {
     LabelText,
     TaggedTeamMembers,
     HelperText,
-    VerticallyCenteredDiv,
 } from "./SnapSubmissionStyles";
 
 export interface Props {

--- a/app/src/components/submissionPage/SubmissionTextBox.tsx
+++ b/app/src/components/submissionPage/SubmissionTextBox.tsx
@@ -72,70 +72,77 @@ const SubmissionTextBox: React.FunctionComponent = (props: Props) => {
     }
 
     return (
-        <div className="container-sm">
-            <SnapSubmissionColumnDiv className="row justify-content-md-center">
-                <div className="d-none d-sm-block col col-lg-5 ">
-                    <SnapCupText>
-                        Add a Snap to the current SnapCup.
-                    </SnapCupText>
-                    <ElleImg className="w-100" />
-                </div>
-                <div className="col col-lg-5">
-                    <form>
-                        <div>
-                            <LabelText>Tag Team Members</LabelText>
-                            <TaggedTeamMembers
-                                type="text"
-                                className="form-control"
-                            />
-                            <HelperText>
-                                Enter their email address or use the @ symbol
-                            </HelperText>
+        <div className="container-sm ">
+            <div className="row">
+                <div className="col col-lg-8">
+                    <SnapSubmissionColumnDiv className="row justify-content-md-center">
+                        <div className="d-none d-sm-block col col-lg-5 ">
+                            <SnapCupText>
+                                Add a Snap to the current SnapCup.
+                            </SnapCupText>
+                            <ElleImg className="w-100" />
                         </div>
-                        <div className="form-group">
-                            <LabelText>Message:</LabelText>
-                            <SnapCupTextArea
-                                className="form-control"
-                                value={message}
-                                onChange={handleMessageTextChanged}
-                                maxLength={GetExtraLength(snappedUsers)}
-                                rows={5}
-                                placeholder="You can tag users using @."
-                            >
-                                <Mention
-                                    style={{
-                                        backgroundColor: "#daf4fa",
-                                        zIndex: 0,
-                                    }}
-                                    trigger="@"
-                                    data={props.snappables}
-                                    rows={5}
-                                />
-                            </SnapCupTextArea>
-                            {confirmation ? (
-                                <OnSubmitMessageDisplay
-                                    confirmation={confirmation}
-                                />
-                            ) : (
-                                <CharactersLeftDisplay
-                                    snappedUsers={snappedUsers}
-                                    message={message}
-                                />
-                            )}
-                            {error ? (
-                                <SubmissionBoxErrorDisplay error={error} />
-                            ) : null}
+                        <div className="col col-lg-7">
+                            <form>
+                                <div>
+                                    <LabelText>Tag Team Members</LabelText>
+                                    <TaggedTeamMembers
+                                        type="text"
+                                        className="form-control"
+                                    />
+                                    <HelperText>
+                                        Enter their email address or use the @
+                                        symbol
+                                    </HelperText>
+                                </div>
+                                <div className="form-group">
+                                    <LabelText>Message:</LabelText>
+                                    <SnapCupTextArea
+                                        className="form-control"
+                                        value={message}
+                                        onChange={handleMessageTextChanged}
+                                        maxLength={GetExtraLength(snappedUsers)}
+                                        rows={5}
+                                        placeholder="You can tag users using @."
+                                    >
+                                        <Mention
+                                            style={{
+                                                backgroundColor: "#daf4fa",
+                                                zIndex: 0,
+                                            }}
+                                            trigger="@"
+                                            data={props.snappables}
+                                            rows={5}
+                                        />
+                                    </SnapCupTextArea>
+                                    {confirmation ? (
+                                        <OnSubmitMessageDisplay
+                                            confirmation={confirmation}
+                                        />
+                                    ) : (
+                                        <CharactersLeftDisplay
+                                            snappedUsers={snappedUsers}
+                                            message={message}
+                                        />
+                                    )}
+                                    {error ? (
+                                        <SubmissionBoxErrorDisplay
+                                            error={error}
+                                        />
+                                    ) : null}
+                                </div>
+                                <SnapItButton
+                                    type="submit"
+                                    className="btn btn-primary"
+                                    onClick={handleSubmit}
+                                >
+                                    Snap it
+                                </SnapItButton>
+                            </form>
                         </div>
-                        <SnapItButton
-                            type="submit"
-                            className="btn btn-primary"
-                            onClick={handleSubmit}
-                        >
-                            Snap it
-                        </SnapItButton>
-                    </form>
+                    </SnapSubmissionColumnDiv>
                 </div>
-            </SnapSubmissionColumnDiv>
+            </div>
         </div>
     );
 };

--- a/app/src/components/submissionPage/SubmissionTextBox.tsx
+++ b/app/src/components/submissionPage/SubmissionTextBox.tsx
@@ -71,6 +71,13 @@ const SubmissionTextBox: React.FunctionComponent = (props: Props) => {
         setSnappedUsers(mentions);
     }
 
+    /* Allows ctrl-enter to submit the form*/
+    function handleKeyPress(e) {
+        if (e.charCode == 13 && e.ctrlKey == true) {
+            handleSubmit(e);
+        }
+    }
+
     return (
         <div className="container-sm ">
             <div className="row">
@@ -103,6 +110,7 @@ const SubmissionTextBox: React.FunctionComponent = (props: Props) => {
                                         onChange={handleMessageTextChanged}
                                         maxLength={GetExtraLength(snappedUsers)}
                                         rows={5}
+                                        onKeyPress={handleKeyPress}
                                         placeholder="You can tag users using @."
                                     >
                                         <Mention

--- a/app/src/components/submissionPage/SubmissionTextBox.tsx
+++ b/app/src/components/submissionPage/SubmissionTextBox.tsx
@@ -20,8 +20,6 @@ import {
     TaggedTeamMembers,
     HelperText,
 } from "./SnapSubmissionStyles";
-// @ts-ignore
-import Elle from "../../images/Elle.svg";
 
 export interface Props {
     snappables: MentionElements[];
@@ -80,7 +78,7 @@ const SubmissionTextBox: React.FunctionComponent = (props: Props) => {
                     <SnapCupText>
                         Add a Snap to the current SnapCup.
                     </SnapCupText>
-                    <ElleImg src={Elle} className="w-100" />
+                    <ElleImg className="w-100" />
                 </div>
                 <div className="col col-lg-5">
                     <form>

--- a/app/src/components/submissionPage/SubmissionTextBox.tsx
+++ b/app/src/components/submissionPage/SubmissionTextBox.tsx
@@ -20,6 +20,8 @@ import {
     TaggedTeamMembers,
     HelperText,
 } from "./SnapSubmissionStyles";
+// @ts-ignore
+import Elle from "../../images/Elle.svg";
 
 export interface Props {
     snappables: MentionElements[];
@@ -78,7 +80,7 @@ const SubmissionTextBox: React.FunctionComponent = (props: Props) => {
                     <SnapCupText>
                         Add a Snap to the current SnapCup.
                     </SnapCupText>
-                    <ElleImg className="w-100" />
+                    <ElleImg src={Elle} className="w-100" />
                 </div>
                 <div className="col col-lg-5">
                     <form>

--- a/app/src/components/submissionPage/SubmissionTextBox.tsx
+++ b/app/src/components/submissionPage/SubmissionTextBox.tsx
@@ -98,7 +98,7 @@ const SubmissionTextBox: React.FunctionComponent = (props: Props) => {
                                 <div className="form-group">
                                     <LabelText>Message:</LabelText>
                                     <SnapCupTextArea
-                                        className="form-control"
+                                        className="form-control finalTextBox"
                                         value={message}
                                         onChange={handleMessageTextChanged}
                                         maxLength={GetExtraLength(snappedUsers)}
@@ -109,7 +109,9 @@ const SubmissionTextBox: React.FunctionComponent = (props: Props) => {
                                             style={{
                                                 backgroundColor: "#daf4fa",
                                                 zIndex: 0,
+                                                outline: "none",
                                             }}
+                                            className="mentions__mention"
                                             trigger="@"
                                             data={props.snappables}
                                             rows={5}


### PR DESCRIPTION
- Resized main element to be 2/3 screen when large and full when mobile.
- reformatted text area to get rid of weird outline
- included padding in text area.
- tag team members now has dark background again. 
- Removed Tagged members 
- Made Submission form centred vertically