### PR TITLE
✨ Improve manage team UI

### DIFF
--- a/app/src/components/adminConsole/AdminConsole.tsx
+++ b/app/src/components/adminConsole/AdminConsole.tsx
@@ -23,17 +23,14 @@ const AdminConsole = () => {
     }, [setIsCup]);
 
     return (
-        <>
-            <hr />
-            <h2>Admin Console</h2>
+        <div className="my-3">
             <SnappableManager />
-            <hr />
             <CurrentCup
                 isCup={isCup}
                 isOpen={false}
                 updateIsCup={updateIsCup}
             />
-        </>
+        </div>
     );
 };
 

--- a/app/src/components/adminConsole/AdminConsole.tsx
+++ b/app/src/components/adminConsole/AdminConsole.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
-import SnappableManager from "./SnappableManager";
+import SnappableManager from "./manageTeam/SnappableManager";
 import CurrentCup from "./currentCup/CurrentCup";
 import { getExistsUnpublished } from "../../firebase/cups/CupService";
 

--- a/app/src/components/adminConsole/AdminConsoleStyles.ts
+++ b/app/src/components/adminConsole/AdminConsoleStyles.ts
@@ -65,3 +65,23 @@ export const SectionHeaderUnderline = styled.p`
 
     border: 1px solid var(--purple-selected);
 `;
+
+export const FileUploadWrapper = styled.span`
+    position: relative;
+    overflow: hidden;
+    input[type="file"] {
+        position: absolute;
+        top: 0;
+        right: 0;
+        min-width: 100%;
+        min-height: 100%;
+        font-size: 100px;
+        text-align: right;
+        filter: alpha(opacity=0);
+        opacity: 0;
+        outline: none;
+        background: white;
+        cursor: inherit;
+        display: block;
+    }
+`;

--- a/app/src/components/adminConsole/AdminConsoleStyles.ts
+++ b/app/src/components/adminConsole/AdminConsoleStyles.ts
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import Elle from "../../images/Elle";
 
 export const SectionHeader = styled.h2`
+    position: relative;
     font-family: Asap;
     font-weight: 500;
     font-size: 30px;
@@ -83,5 +84,18 @@ export const FileUploadWrapper = styled.span`
         background: white;
         cursor: inherit;
         display: block;
+    }
+`;
+
+export const StyledDownloadButton = styled.button`
+    all: unset;
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    img {
+        height: 30px;
+        width: auto;
+        margin: 0;
+        padding: 0;
     }
 `;

--- a/app/src/components/adminConsole/SnappableManager.tsx
+++ b/app/src/components/adminConsole/SnappableManager.tsx
@@ -1,6 +1,10 @@
 import React, { useState, useRef, useCallback } from "react";
 import getSnappables from "../../firebase/users/GetSnappables";
-import { FileUploadWrapper } from "./AdminConsoleStyles";
+import {
+    FileUploadWrapper,
+    SectionHeader,
+    SectionHeaderUnderline,
+} from "./AdminConsoleStyles";
 import { snappablesToCsvDownload, readFileAndUpload } from "./csvManager";
 
 const LOADING = "loading";
@@ -9,7 +13,7 @@ const ERROR = "error";
 
 const SnappableManager = () => {
     const [status, setStatus] = useState({ status: IDLE });
-    const [filetext, setFiletext] = useState("Browse...");
+    const [filename, setFilename] = useState<String | null>(null);
     const fileRef = useRef(null);
 
     const downloadSnappables = useCallback(() => {
@@ -55,12 +59,13 @@ const SnappableManager = () => {
     });
 
     const handleFilenameChange = (event) => {
-        setFiletext(event.target.files[0]?.name ?? "Browse");
+        setFilename(event.target.files[0]?.name ?? null);
     };
 
     return (
         <>
-            <h5>Snappable People</h5>
+            <SectionHeader className="mb-2">Manage Team</SectionHeader>
+            <SectionHeaderUnderline />
             <p>
                 When uploading the list of snappable people please leave the ID
                 cell blank for new users. Leaving the ID column blank tells the
@@ -75,22 +80,17 @@ const SnappableManager = () => {
                 to download the list of users, make edits to it, then reupload
                 it.
             </p>
-            <div
-                role="group"
-                className="mb-3"
-                aria-label="Buttons for manipulating data"
+            <button
+                className="btn btn-outline-purple btn-sm"
+                onClick={downloadSnappables}
+                disabled={status.status === LOADING}
             >
-                <button
-                    className="btn btn-purple"
-                    onClick={downloadSnappables}
-                    disabled={status.status === LOADING}
-                >
-                    Download as CSV
-                </button>
-            </div>
-            <form onSubmit={uploadSnappables}>
-                <FileUploadWrapper className="btn">
-                    {filetext}
+                Download existing list of snappable people as CSV
+            </button>
+            <form onSubmit={uploadSnappables} className="my-3">
+                <FileUploadWrapper className="btn btn-outline-purple mr-2 btn-sm">
+                    {filename ??
+                        "Browse files to upload a list of snappable people..."}
                     <input
                         type="file"
                         ref={fileRef}
@@ -99,9 +99,11 @@ const SnappableManager = () => {
                         onChange={handleFilenameChange}
                     />
                 </FileUploadWrapper>
-                <button type="submit" className="btn btn-purple">
-                    Upload complete list of users
-                </button>
+                {filename && (
+                    <button type="submit" className="btn btn-purple btn-sm">
+                        Upload complete list of users
+                    </button>
+                )}
                 {status.status !== IDLE && (
                     <p>
                         {status.status === ERROR ? (

--- a/app/src/components/adminConsole/SnappableManager.tsx
+++ b/app/src/components/adminConsole/SnappableManager.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useCallback } from "react";
 import getSnappables from "../../firebase/users/GetSnappables";
+import { FileUploadWrapper } from "./AdminConsoleStyles";
 import { snappablesToCsvDownload, readFileAndUpload } from "./csvManager";
 
 const LOADING = "loading";
@@ -8,6 +9,7 @@ const ERROR = "error";
 
 const SnappableManager = () => {
     const [status, setStatus] = useState({ status: IDLE });
+    const [filetext, setFiletext] = useState("Browse...");
     const fileRef = useRef(null);
 
     const downloadSnappables = useCallback(() => {
@@ -52,6 +54,10 @@ const SnappableManager = () => {
         })();
     });
 
+    const handleFilenameChange = (event) => {
+        setFiletext(event.target.files[0]?.name ?? "Browse");
+    };
+
     return (
         <>
             <h5>Snappable People</h5>
@@ -70,41 +76,42 @@ const SnappableManager = () => {
                 it.
             </p>
             <div
-                className="btn-group ml-2"
                 role="group"
+                className="mb-3"
                 aria-label="Buttons for manipulating data"
             >
                 <button
-                    type="button"
-                    className="btn btn-primary"
-                    onClick={() => downloadSnappables()}
+                    className="btn btn-purple"
+                    onClick={downloadSnappables}
                     disabled={status.status === LOADING}
                 >
                     Download as CSV
                 </button>
             </div>
             <form onSubmit={uploadSnappables}>
-                <input
-                    type="file"
-                    ref={fileRef}
-                    disabled={status.status === LOADING}
-                    accept=".csv"
-                />
-                <input
-                    type="submit"
-                    className="btn btn-purple"
-                    value="Upload complete list of users."
-                />
+                <FileUploadWrapper className="btn">
+                    {filetext}
+                    <input
+                        type="file"
+                        ref={fileRef}
+                        disabled={status.status === LOADING}
+                        accept=".csv"
+                        onChange={handleFilenameChange}
+                    />
+                </FileUploadWrapper>
+                <button type="submit" className="btn btn-purple">
+                    Upload complete list of users
+                </button>
+                {status.status !== IDLE && (
+                    <p>
+                        {status.status === ERROR ? (
+                            <span className="text-danger">{status.error}</span>
+                        ) : (
+                            <b>Loading...</b>
+                        )}
+                    </p>
+                )}
             </form>
-            {status.status !== IDLE && (
-                <p>
-                    {status.status === ERROR ? (
-                        <span className="text-danger">{status.error}</span>
-                    ) : (
-                        <b>Loading...</b>
-                    )}
-                </p>
-            )}
         </>
     );
 };

--- a/app/src/components/adminConsole/manageTeam/DownloadButton.tsx
+++ b/app/src/components/adminConsole/manageTeam/DownloadButton.tsx
@@ -1,12 +1,10 @@
-import React, { useCallback } from "react";
+import React from "react";
 import DownloadIcon from "../../../images/DownloadIcon";
 import { StyledDownloadButton } from "../AdminConsoleStyles";
 
 const DownloadButton = (props: { disabled: boolean; onClick: () => void }) => {
-    const onClick = useCallback(props.onClick, []);
-
     return (
-        <StyledDownloadButton onClick={onClick} disabled={props.disabled}>
+        <StyledDownloadButton onClick={props.onClick} disabled={props.disabled}>
             <DownloadIcon />
         </StyledDownloadButton>
     );

--- a/app/src/components/adminConsole/manageTeam/DownloadButton.tsx
+++ b/app/src/components/adminConsole/manageTeam/DownloadButton.tsx
@@ -1,0 +1,15 @@
+import React, { useCallback } from "react";
+import DownloadIcon from "../../../images/DownloadIcon";
+import { StyledDownloadButton } from "../AdminConsoleStyles";
+
+const DownloadButton = (props: { disabled: boolean; onClick: () => void }) => {
+    const onClick = useCallback(props.onClick, []);
+
+    return (
+        <StyledDownloadButton onClick={onClick} disabled={props.disabled}>
+            <DownloadIcon />
+        </StyledDownloadButton>
+    );
+};
+
+export default DownloadButton;

--- a/app/src/components/adminConsole/manageTeam/SnappableManager.tsx
+++ b/app/src/components/adminConsole/manageTeam/SnappableManager.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useRef, useCallback } from "react";
-import getSnappables from "../../firebase/users/GetSnappables";
+import getSnappables from "../../../firebase/users/GetSnappables";
 import {
     FileUploadWrapper,
     SectionHeader,
     SectionHeaderUnderline,
-} from "./AdminConsoleStyles";
-import { snappablesToCsvDownload, readFileAndUpload } from "./csvManager";
+} from "../AdminConsoleStyles";
+import { snappablesToCsvDownload, readFileAndUpload } from "../csvManager";
+import DownloadButton from "./DownloadButton";
 
 const LOADING = "loading";
 const IDLE = "idle";
@@ -16,7 +17,7 @@ const SnappableManager = () => {
     const [filename, setFilename] = useState<String | null>(null);
     const fileRef = useRef(null);
 
-    const downloadSnappables = useCallback(() => {
+    const downloadSnappables = () => {
         setStatus({ status: LOADING });
         (async () => {
             try {
@@ -31,7 +32,7 @@ const SnappableManager = () => {
                 });
             }
         })();
-    }, []);
+    };
 
     const uploadSnappables = useCallback((event) => {
         event.preventDefault();
@@ -64,7 +65,13 @@ const SnappableManager = () => {
 
     return (
         <>
-            <SectionHeader className="mb-2">Manage Team</SectionHeader>
+            <SectionHeader className="mb-2">
+                Manage Team{" "}
+                <DownloadButton
+                    onClick={downloadSnappables}
+                    disabled={status.status === LOADING}
+                />
+            </SectionHeader>
             <SectionHeaderUnderline />
             <p>
                 When uploading the list of snappable people please leave the ID
@@ -80,13 +87,6 @@ const SnappableManager = () => {
                 to download the list of users, make edits to it, then reupload
                 it.
             </p>
-            <button
-                className="btn btn-outline-purple btn-sm"
-                onClick={downloadSnappables}
-                disabled={status.status === LOADING}
-            >
-                Download existing list of snappable people as CSV
-            </button>
             <form onSubmit={uploadSnappables} className="my-3">
                 <FileUploadWrapper className="btn btn-outline-purple mr-2 btn-sm">
                     {filename ??

--- a/app/src/components/adminConsole/manageTeam/SnappableManager.tsx
+++ b/app/src/components/adminConsole/manageTeam/SnappableManager.tsx
@@ -17,7 +17,7 @@ const SnappableManager = () => {
     const [filename, setFilename] = useState<String | null>(null);
     const fileRef = useRef(null);
 
-    const downloadSnappables = () => {
+    const onClickDownload = useCallback(() => {
         setStatus({ status: LOADING });
         (async () => {
             try {
@@ -32,7 +32,7 @@ const SnappableManager = () => {
                 });
             }
         })();
-    };
+    }, [setStatus]);
 
     const uploadSnappables = useCallback((event) => {
         event.preventDefault();
@@ -68,7 +68,7 @@ const SnappableManager = () => {
             <SectionHeader className="mb-2">
                 Manage Team{" "}
                 <DownloadButton
-                    onClick={downloadSnappables}
+                    onClick={onClickDownload}
                     disabled={status.status === LOADING}
                 />
             </SectionHeader>

--- a/app/src/images/DownloadIcon.svg
+++ b/app/src/images/DownloadIcon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#3a09a1"><g><rect fill="none" height="24" width="24"/></g><g><path d="M18,15v3H6v-3H4v3c0,1.1,0.9,2,2,2h12c1.1,0,2-0.9,2-2v-3H18z M17,11l-1.41-1.41L13,12.17V4h-2v8.17L8.41,9.59L7,11l5,5 L17,11z"/></g></svg>

--- a/app/src/images/DownloadIcon.tsx
+++ b/app/src/images/DownloadIcon.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+// @ts-ignore
+import downloadIcon from "./DownloadIcon.svg";
+
+const DownloadIcon = (props) => <img src={downloadIcon} {...props} />;
+
+export default DownloadIcon;

--- a/app/src/images/__mocks__/DownloadIcon.tsx
+++ b/app/src/images/__mocks__/DownloadIcon.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+const DownloadIcon = () => <img />;
+
+export default DownloadIcon;


### PR DESCRIPTION
This PR is to improve the manage team file upload and download widgets and buttons

- The submit file button is now hidden until a file is actually selected
- The default file upload widget is styled a bit more nicely to fit the designs
- The section header was styled more like the designs
- The download button now is an icon on the right as per the designs

## How it looks with no file selected
![no-file](https://user-images.githubusercontent.com/57836187/114384459-a91b6580-9b86-11eb-84c1-7c805011aed0.PNG)


## How it looks after a file is selected
![file-selected](https://user-images.githubusercontent.com/57836187/114384491-b0427380-9b86-11eb-95fb-1ea95e99594a.PNG)

