### PR TITLE
Download a spreadsheet containing all the submitted snaps.

### DIFF
--- a/app/src/components/adminConsole/AdminConsole.tsx
+++ b/app/src/components/adminConsole/AdminConsole.tsx
@@ -32,7 +32,7 @@ const AdminConsole = () => {
                 updateIsCup={updateIsCup}
             />
             <ExportAllSnaps />
-        </>
+        </div>
     );
 };
 

--- a/app/src/components/adminConsole/AdminConsole.tsx
+++ b/app/src/components/adminConsole/AdminConsole.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import SnappableManager from "./manageTeam/SnappableManager";
 import CurrentCup from "./currentCup/CurrentCup";
 import { getExistsUnpublished } from "../../firebase/cups/CupService";
+import ExportAllSnaps from "./ExportAllSnaps";
 
 const AdminConsole = () => {
     const [isCup, setIsCup] = useState<Boolean>(false);
@@ -30,7 +31,8 @@ const AdminConsole = () => {
                 isOpen={false}
                 updateIsCup={updateIsCup}
             />
-        </div>
+            <ExportAllSnaps />
+        </>
     );
 };
 

--- a/app/src/components/adminConsole/ExportAllSnaps.tsx
+++ b/app/src/components/adminConsole/ExportAllSnaps.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from "react";
 import getSnaps from "../../firebase/snaps/GetSnaps";
-import { snapsToCsvContent, csvContentToCsvDownload } from "./csvManager";
+import { snapsToCsvDownload } from "./csvManager";
 
 const LOADING = "loading";
 const IDLE = "idle";
@@ -14,7 +14,7 @@ const ExportAllSnaps = () => {
         (async () => {
             try {
                 const snaps = await getSnaps();
-                csvContentToCsvDownload(snapsToCsvContent(snaps), "snaps.csv");
+                snapsToCsvDownload(snaps);
                 setStatus({ status: IDLE });
             } catch (err) {
                 console.error(err);
@@ -28,7 +28,7 @@ const ExportAllSnaps = () => {
 
     return (
         <div>
-            <h1>Export all snaps</h1>
+            <h2>Export all snaps</h2>
             <p>
                 To get all of the snaps sent, press the download snaps button.
             </p>

--- a/app/src/components/adminConsole/ExportAllSnaps.tsx
+++ b/app/src/components/adminConsole/ExportAllSnaps.tsx
@@ -1,0 +1,77 @@
+import React, { useState, useCallback } from "react";
+import getSnaps from "../../firebase/snaps/GetSnaps";
+import { snapsToCsvContent, csvContentToCsvDownload } from "./csvManager";
+
+const LOADING = "loading";
+const IDLE = "idle";
+const ERROR = "error";
+
+const ExportAllSnaps = () => {
+    const [status, setStatus] = useState({ status: IDLE });
+
+    function snapsToCsvDownload(csvContent, filename = "snaps.csv") {
+        stringToFileDownload(csvContent, filename, "text/csv;charset=utf-8;");
+    }
+
+    function stringToFileDownload(
+        content: string,
+        filename: string,
+        type = "text/csv;charset=utf-8;"
+    ) {
+        var blob = new Blob([content], { type });
+        var link = document.createElement("a");
+        if (link.download !== undefined) {
+            // feature detection
+            // Browsers that support HTML5 download attribute
+            var url = URL.createObjectURL(blob);
+            link.setAttribute("href", url);
+            link.setAttribute("download", filename);
+            link.style.visibility = "hidden";
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        }
+    }
+
+    const downloadSnaps = useCallback(() => {
+        setStatus({ status: LOADING });
+        (async () => {
+            try {
+                const snappables = await getSnaps();
+                csvContentToCsvDownload(
+                    snapsToCsvContent(snappables),
+                    "snaps.csv"
+                );
+                setStatus({ status: IDLE });
+            } catch (err) {
+                console.error(err);
+                setStatus({
+                    status: ERROR,
+                    error: "There was an error loading snappable people.",
+                });
+            }
+        })();
+    }, []);
+
+    return (
+        <div>
+            <h1>Export</h1>
+            <div
+                className="btn-group ml-2"
+                role="group"
+                aria-label="Buttons for manipulating data"
+            >
+                <button
+                    type="button"
+                    className="btn btn-primary"
+                    onClick={() => downloadSnaps()}
+                    disabled={status.status === LOADING}
+                >
+                    Download as CSV
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default ExportAllSnaps;

--- a/app/src/components/adminConsole/ExportAllSnaps.tsx
+++ b/app/src/components/adminConsole/ExportAllSnaps.tsx
@@ -9,45 +9,18 @@ const ERROR = "error";
 const ExportAllSnaps = () => {
     const [status, setStatus] = useState({ status: IDLE });
 
-    function snapsToCsvDownload(csvContent, filename = "snaps.csv") {
-        stringToFileDownload(csvContent, filename, "text/csv;charset=utf-8;");
-    }
-
-    function stringToFileDownload(
-        content: string,
-        filename: string,
-        type = "text/csv;charset=utf-8;"
-    ) {
-        var blob = new Blob([content], { type });
-        var link = document.createElement("a");
-        if (link.download !== undefined) {
-            // feature detection
-            // Browsers that support HTML5 download attribute
-            var url = URL.createObjectURL(blob);
-            link.setAttribute("href", url);
-            link.setAttribute("download", filename);
-            link.style.visibility = "hidden";
-            document.body.appendChild(link);
-            link.click();
-            document.body.removeChild(link);
-        }
-    }
-
     const downloadSnaps = useCallback(() => {
         setStatus({ status: LOADING });
         (async () => {
             try {
-                const snappables = await getSnaps();
-                csvContentToCsvDownload(
-                    snapsToCsvContent(snappables),
-                    "snaps.csv"
-                );
+                const snaps = await getSnaps();
+                csvContentToCsvDownload(snapsToCsvContent(snaps), "snaps.csv");
                 setStatus({ status: IDLE });
             } catch (err) {
                 console.error(err);
                 setStatus({
                     status: ERROR,
-                    error: "There was an error loading snappable people.",
+                    error: "There was an error loading snaps.",
                 });
             }
         })();
@@ -55,7 +28,10 @@ const ExportAllSnaps = () => {
 
     return (
         <div>
-            <h1>Export</h1>
+            <h1>Export all snaps</h1>
+            <p>
+                To get all of the snaps sent, press the download snaps button.
+            </p>
             <div
                 className="btn-group ml-2"
                 role="group"

--- a/app/src/components/adminConsole/csvManager.ts
+++ b/app/src/components/adminConsole/csvManager.ts
@@ -2,7 +2,7 @@ import firebase from "firebase/app";
 import "firebase/functions";
 import { formatBody } from "../../components/submissionPage/helpers/snapFormatting";
 
-export function snappablesToCsvContent(snappables) {
+function snappablesToCsvContent(snappables) {
     let csvContent = "id,fullName,email,username";
     snappables.forEach(({ id, fullName, email, username }) => {
         csvContent += `\n${id},${fullName},${email},${username}`;
@@ -10,14 +10,15 @@ export function snappablesToCsvContent(snappables) {
     return csvContent;
 }
 
-export function snapsToCsvContent(snaps) {
+function snapsToCsvContent(snaps) {
     let csvContent = "messages";
     snaps.forEach(({ to, from, body, timestamp }) => {
         csvContent += `\n${formatBody(body)}`;
     });
     return csvContent;
 }
-export function stringToFileDownload(
+
+function stringToFileDownload(
     content: string,
     filename: string,
     type = "text/csv;charset=utf-8;"

--- a/app/src/components/adminConsole/csvManager.ts
+++ b/app/src/components/adminConsole/csvManager.ts
@@ -1,9 +1,6 @@
 import firebase from "firebase/app";
 import "firebase/functions";
-import {
-    getBodyElements,
-    BodyElement,
-} from "../../components/submissionPage/helpers/snapFormatting";
+import { formatBody } from "../../components/submissionPage/helpers/snapFormatting";
 
 export function snappablesToCsvContent(snappables) {
     let csvContent = "id,fullName,email,username";
@@ -13,19 +10,9 @@ export function snappablesToCsvContent(snappables) {
     return csvContent;
 }
 
-/* Formats the body of a snap so the meta data is removed */
-function formatBody(body: string) {
-    var newBody = "";
-    const bodyElems = getBodyElements(body);
-    for (var elem of bodyElems) {
-        newBody += elem.text;
-    }
-    return newBody;
-}
-
-export function snapsToCsvContent(snappables) {
+export function snapsToCsvContent(snaps) {
     let csvContent = "messages";
-    snappables.forEach(({ to, from, body, timestamp }) => {
+    snaps.forEach(({ to, from, body, timestamp }) => {
         csvContent += `\n${formatBody(body)}`;
     });
     return csvContent;
@@ -50,11 +37,18 @@ export function stringToFileDownload(
     }
 }
 
-export function csvContentToCsvDownload(
-    csvContent,
-    filename = "snappable_list.csv"
-) {
-    stringToFileDownload(csvContent, filename, "text/csv;charset=utf-8;");
+export function snapsToCsvDownload(snaps) {
+    const csvContent = snapsToCsvContent(snaps);
+    stringToFileDownload(csvContent, "snaps", "text/csv;charset=utf-8;");
+}
+
+export function snappablesToCsvDownload(snappables) {
+    const csvContent = snappablesToCsvContent(snappables);
+    stringToFileDownload(
+        csvContent,
+        "snappable_list.csv",
+        "text/csv;charset=utf-8;"
+    );
 }
 
 function assertSnappableRecordValid(fullName, email, username, i = null) {

--- a/app/src/components/adminConsole/csvManager.ts
+++ b/app/src/components/adminConsole/csvManager.ts
@@ -1,7 +1,11 @@
 import firebase from "firebase/app";
 import "firebase/functions";
+import {
+    getBodyElements,
+    BodyElement,
+} from "../../components/submissionPage/helpers/snapFormatting";
 
-function snappablesToCsvContent(snappables) {
+export function snappablesToCsvContent(snappables) {
     let csvContent = "id,fullName,email,username";
     snappables.forEach(({ id, fullName, email, username }) => {
         csvContent += `\n${id},${fullName},${email},${username}`;
@@ -9,7 +13,24 @@ function snappablesToCsvContent(snappables) {
     return csvContent;
 }
 
-function stringToFileDownload(
+/* Formats the body of a snap so the meta data is removed */
+function formatBody(body: string) {
+    var newBody = "";
+    const bodyElems = getBodyElements(body);
+    for (var elem of bodyElems) {
+        newBody += elem.text;
+    }
+    return newBody;
+}
+
+export function snapsToCsvContent(snappables) {
+    let csvContent = "messages";
+    snappables.forEach(({ to, from, body, timestamp }) => {
+        csvContent += `\n${formatBody(body)}`;
+    });
+    return csvContent;
+}
+export function stringToFileDownload(
     content: string,
     filename: string,
     type = "text/csv;charset=utf-8;"
@@ -29,11 +50,10 @@ function stringToFileDownload(
     }
 }
 
-export function snappablesToCsvDownload(
-    snappables,
+export function csvContentToCsvDownload(
+    csvContent,
     filename = "snappable_list.csv"
 ) {
-    const csvContent = snappablesToCsvContent(snappables);
     stringToFileDownload(csvContent, filename, "text/csv;charset=utf-8;");
 }
 

--- a/app/src/components/adminConsole/manageTeam/SnappableManager.tsx
+++ b/app/src/components/adminConsole/manageTeam/SnappableManager.tsx
@@ -1,10 +1,6 @@
 import React, { useState, useRef, useCallback } from "react";
 import getSnappables from "../../firebase/users/GetSnappables";
-import {
-    csvContentToCsvDownload,
-    readFileAndUpload,
-    snappablesToCsvContent,
-} from "./csvManager";
+import { snappablesToCsvDownload, readFileAndUpload } from "./csvManager";
 
 const LOADING = "loading";
 const IDLE = "idle";
@@ -20,7 +16,7 @@ const SnappableManager = () => {
         (async () => {
             try {
                 const snappables = await getSnappables();
-                csvContentToCsvDownload(snappablesToCsvContent(snappables));
+                snappablesToCsvDownload(snappables);
                 setStatus({ status: IDLE });
             } catch (err) {
                 console.error(err);

--- a/app/src/components/adminConsole/manageTeam/SnappableManager.tsx
+++ b/app/src/components/adminConsole/manageTeam/SnappableManager.tsx
@@ -1,12 +1,10 @@
 import React, { useState, useRef, useCallback } from "react";
-import getSnappables from "../../../firebase/users/GetSnappables";
+import getSnappables from "../../firebase/users/GetSnappables";
 import {
-    FileUploadWrapper,
-    SectionHeader,
-    SectionHeaderUnderline,
-} from "../AdminConsoleStyles";
-import { snappablesToCsvDownload, readFileAndUpload } from "../csvManager";
-import DownloadButton from "./DownloadButton";
+    csvContentToCsvDownload,
+    readFileAndUpload,
+    snappablesToCsvContent,
+} from "./csvManager";
 
 const LOADING = "loading";
 const IDLE = "idle";
@@ -22,7 +20,7 @@ const SnappableManager = () => {
         (async () => {
             try {
                 const snappables = await getSnappables();
-                snappablesToCsvDownload(snappables);
+                csvContentToCsvDownload(snappablesToCsvContent(snappables));
                 setStatus({ status: IDLE });
             } catch (err) {
                 console.error(err);

--- a/app/src/components/adminConsole/manageTeam/SnappableManager.tsx
+++ b/app/src/components/adminConsole/manageTeam/SnappableManager.tsx
@@ -1,6 +1,12 @@
 import React, { useState, useRef, useCallback } from "react";
-import getSnappables from "../../firebase/users/GetSnappables";
-import { snappablesToCsvDownload, readFileAndUpload } from "./csvManager";
+import getSnappables from "../../../firebase/users/GetSnappables";
+import {
+    FileUploadWrapper,
+    SectionHeader,
+    SectionHeaderUnderline,
+} from "../AdminConsoleStyles";
+import { snappablesToCsvDownload, readFileAndUpload } from "../csvManager";
+import DownloadButton from "./DownloadButton";
 
 const LOADING = "loading";
 const IDLE = "idle";
@@ -10,7 +16,6 @@ const SnappableManager = () => {
     const [status, setStatus] = useState({ status: IDLE });
     const [filename, setFilename] = useState<String | null>(null);
     const fileRef = useRef(null);
-
     const onClickDownload = useCallback(() => {
         setStatus({ status: LOADING });
         (async () => {

--- a/app/src/components/submissionPage/helpers/snapFormatting.ts
+++ b/app/src/components/submissionPage/helpers/snapFormatting.ts
@@ -33,3 +33,13 @@ export function getBodyElements(body: string): BodyElement[] {
     }
     return bodyElements;
 }
+
+/* Formats the body of a snap so the meta data is removed */
+export function formatBody(body: string) {
+    var newBody = "";
+    const bodyElems = getBodyElements(body);
+    for (var elem of bodyElems) {
+        newBody += elem.text;
+    }
+    return newBody;
+}

--- a/app/src/components/submissionPage/helpers/snapFormatting.ts
+++ b/app/src/components/submissionPage/helpers/snapFormatting.ts
@@ -8,7 +8,7 @@ export function formatTimestamp(date: Date): string {
     });
 }
 
-interface BodyElement {
+export interface BodyElement {
     text: string;
     isTag: boolean;
 }

--- a/app/src/firebase/snaps/GetSnaps.ts
+++ b/app/src/firebase/snaps/GetSnaps.ts
@@ -1,0 +1,16 @@
+import firebase from "firebase/app";
+import Snap from "../../types/Snap";
+
+/* Gets a list of Snaps */
+export default async function getSnaps(): Promise<Snap[]> {
+    const querySnapshot = await firebase
+        .firestore()
+        .collection("snaps")
+        .get({ source: "server" });
+    const result = querySnapshot.docs.map((doc) => {
+        console.log(doc.data());
+        const { body, from, to, timestamp } = doc.data();
+        return { to, from, body, timestamp };
+    });
+    return result;
+}


### PR DESCRIPTION
- On Manage Admin I've added an Export Snaps section 
- [Export Snaps Section](https://trello-attachments.s3.amazonaws.com/6061e12076321f0b73587547/606b4c7bde45b00a2e27ea3d/21e95233a5e0f951e6959ad5bc933c04/unknown.png)
- That has a button  which allows you to download the body of all snaps sent. 
- Applied Nina's regex function to remove the metadata around the snap.
- Csv Files only contain the body of a snap in a column called message.
- [CSV File Example](https://cdn.discordapp.com/attachments/807319024819109909/831116262330859610/unknown.png)