### PR TITLE
Delete icon disappears if Snapcup has closed.

### DIFF
--- a/app/src/components/submissionPage/SnapList.tsx
+++ b/app/src/components/submissionPage/SnapList.tsx
@@ -90,9 +90,13 @@ const SnapList: React.FunctionComponent<SnapListProps> = ({ snaps, cup }) => {
                     <SnapCardFooter>
                         {formatTimestamp(snap.timestamp)}
                         <SnapCardSpacer />
-                        <TrashButton onClick={() => onDeleteSnapPressed(snap)}>
-                            <StyledTrashIcon alt="Delete snap" />
-                        </TrashButton>
+                        {cup.isOpen && (
+                            <TrashButton
+                                onClick={() => onDeleteSnapPressed(snap)}
+                            >
+                                <StyledTrashIcon alt="Delete snap" />
+                            </TrashButton>
+                        )}
                     </SnapCardFooter>
                 </SnapText>
             </SnapCard>


### PR DESCRIPTION
Adams changes made this quite easy. 