### PR TITLE
🖌️ Change current cup title wording and add some spacing above that header

### DIFF
--- a/app/src/components/submissionPage/SubmissionBoxWrapper.tsx
+++ b/app/src/components/submissionPage/SubmissionBoxWrapper.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { SnapSubmissionColumnDiv } from "./SnapSubmissionStyles";
 
 const SubmissionBoxWrapper: React.FunctionComponent = ({ children }) => (
-    <div className="col">
+    <div className="col mb-4">
         <div className="row">
             <div className="col col-lg-8">
                 <SnapSubmissionColumnDiv className="row justify-content-md-center">

--- a/app/src/components/submissionPage/YourSnaps.tsx
+++ b/app/src/components/submissionPage/YourSnaps.tsx
@@ -54,7 +54,7 @@ const YourSnaps: React.FunctionComponent = ({ cup }) => {
     return (
         <div>
             <SectionHeading title={"SnapCups"} />
-            <SnapCupName>CupName {cup.name}</SnapCupName>
+            <SnapCupName>Current cup: {cup.name}</SnapCupName>
             {error && <p>Error: {error}</p>}
             <PublishedStatus>
                 {cup.isPublished ? "Published" : "Not yet published."}


### PR DESCRIPTION
The card *The 'Your Snaps' section should only display snaps from the current cup* is technically already implemented so this PR simply rewords the title to remove "CupName" which is a bit strange to have and also I've added a bit of space above that header.

The trello card *Users **should** see the name of an open unpublished cup in the submission panel* is also already done I think so I've moved in to "in review".

### How it looks with these changes

![padding](https://user-images.githubusercontent.com/57836187/114567219-ea854100-9c6a-11eb-88bb-940d8841eaab.PNG)


